### PR TITLE
pyLsdのエラーのインストール方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ pip install pylsd
 python3の方は対応させた別バージョン
 ```
 pip install "ocrd-fork-pylsd == 0.0.3"
-`
+```
 
 ### ImportError: cannot import name 'lsd' from 'lsd'
 
-pip install opencv-contrib-python``
+pip install opencv-contrib-python
+
 
 ## ディレクトリ構成
 ```

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ pip install "ocrd-fork-pylsd == 0.0.3"
 ```
 
 ### ImportError: cannot import name 'lsd' from 'lsd'
-
+このエラーが出たら下記のコマンドを入力する
 pip install opencv-contrib-python
-
 
 ## ディレクトリ構成
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ pip install pylsd
 python3の方は対応させた別バージョン
 ```
 pip install "ocrd-fork-pylsd == 0.0.3"
-```
+`
+
+### ImportError: cannot import name 'lsd' from 'lsd'
+
+pip install opencv-contrib-python``
 
 ## ディレクトリ構成
 ```


### PR DESCRIPTION
## 概要
ImportError: cannot import name 'lsd' from 'lsd'

## 実装内容
- [ ]
- Install following command: pip install opencv-contrib-python`

## 実行結果


## その他
